### PR TITLE
feat: add option to skip drafts

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,9 @@ inputs:
   SKIP_LABELS:
     description: 'The comma separated labels string. If an open pull-request has one of those label then this action will skip adding the attention label.'
     default: 'work-in-progress,wip'
+  SKIP_DRAFTS:
+    description: 'Wheter to skip draft PRs or not. Defaults to include them'
+    default: true
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -74,7 +74,7 @@ for PULL_REQUEST in $PULL_REQUESTS; do
 
   if [[ $SKIP_DRAFTS != "false" ]]; then
     IS_A_DRAFT=$(echo "$PULL_REQUEST_INFO" | jq --raw-output '.draft')
-    if [[ $IS_A_DRAFT ]]; then
+    if [[ $IS_A_DRAFT == "true" ]]; then
       echo "Ignoring, this pull request because it's a DRAFT"
       continue
     fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,6 +21,11 @@ if [[ -z "$AFTER_DAYS" ]]; then
   AFTER_DAYS=3
 fi
 
+if [[ -z "$SKIP_DRAFTS" ]]; then
+  echo "Setting the default SKIP_DRAFTS variable value."
+  SKIP_DRAFTS=false
+fi
+
 URI="https://api.github.com"
 API_HEADER="Accept: application/vnd.github.v3+json"
 AUTH_HEADER="Authorization: token $GITHUB_TOKEN"
@@ -33,7 +38,7 @@ OPEN_PULL_REQUESTS=$(
     "$URI/repos/$GITHUB_REPOSITORY/issues?state=open"
   )
 
-PULL_REQUESTS=$(echo "$OPEN_PULL_REQUESTS" | jq --raw-output '.[] | {number: .number, created_at: .created_at, labels: .labels} | @base64')
+PULL_REQUESTS=$(echo "$OPEN_PULL_REQUESTS" | jq --raw-output '.[] | {number: .number, created_at: .created_at, labels: .labels, draft: .draft} | @base64')
 
 for PULL_REQUEST in $PULL_REQUESTS; do
   PULL_REQUEST_INFO="$(echo "$PULL_REQUEST" | base64 -d)"
@@ -64,6 +69,17 @@ for PULL_REQUEST in $PULL_REQUESTS; do
   done
 
   if [[ "$IS_SKIP_LABEL_NAME_EXIST" == "true" ]]; then
+    continue
+  fi
+
+  if [[ $SKIP_DRAFTS -ne false ]]; then
+    IS_A_DRAFT=$(echo "$PULL_REQUEST_INFO" | jq --raw-output '.draft')
+    if [[ $IS_A_DRAFT ]]; then
+      echo "Ignoring, this pull request is a DRAFT"
+      continue
+    fi
+  else
+    echo "Proceeding without draft"
     continue
   fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -72,15 +72,12 @@ for PULL_REQUEST in $PULL_REQUESTS; do
     continue
   fi
 
-  if [[ $SKIP_DRAFTS -ne false ]]; then
+  if [[ $SKIP_DRAFTS != "false" ]]; then
     IS_A_DRAFT=$(echo "$PULL_REQUEST_INFO" | jq --raw-output '.draft')
     if [[ $IS_A_DRAFT ]]; then
-      echo "Ignoring, this pull request is a DRAFT"
+      echo "Ignoring, this pull request because it's a DRAFT"
       continue
     fi
-  else
-    echo "Proceeding without draft"
-    continue
   fi
 
   CREATED_AT=$(echo "$PULL_REQUEST_INFO" | jq --raw-output '.created_at')


### PR DESCRIPTION
This adds the option `SKIP_DRAFTS` to the Github Action.
The action then checks if the pull rrequest is a draft or not. Skipping labelling if enabled (set to true) + PR is draft.

Default behavior is still to include drafts.